### PR TITLE
Fix for SET NAMES utf8 causing an unknown encoding error

### DIFF
--- a/lib/constants/encoding_charset.js
+++ b/lib/constants/encoding_charset.js
@@ -46,4 +46,5 @@ module.exports = {
   cp932: 95,
   eucjpms: 97,
   gb18030: 248,
+  utf8mb3: 192,
 };

--- a/lib/packets/resultset_header.js
+++ b/lib/packets/resultset_header.js
@@ -64,7 +64,13 @@ class ResultSetHeader {
             stateChanges.systemVariables[key] = val;
             if (key === 'character_set_client') {
               const charsetNumber = EncodingToCharset[val];
-              connection.config.charsetNumber = charsetNumber;
+              // TODO - better api for driver users to handle unknown encodings?
+              // maybe custom coverter in the config?
+              // For now just ignore character_set_client command if there is
+              // no known mapping from reported encoding to a charset code
+              if (typeof charsetNumber !== 'undefined') {
+                connection.config.charsetNumber = charsetNumber;
+              }
             }
           } else if (type === sessionInfoTypes.SCHEMA) {
             key = packet.readLengthCodedString(encoding);


### PR DESCRIPTION
This pull request addresses an issue in the `malinosqui/node-mysql2` repository where executing `SET NAMES utf8` could result in an unknown encoding error. The changes include:

1. **lib/constants/encoding_charset.js**: A mapping for the `utf8mb3` character set has been added. However, the mapping uses a collation ID instead of a character set ID, which may be incorrect and could potentially lead to issues.

2. **lib/packets/resultset_header.js**: A defensive check has been implemented to prevent `connection.config.charsetNumber` from being set to `undefined` when the server sends an unknown character set. This enhancement ensures that the charset number is only updated when a valid mapping is available, thereby improving the robustness of session state handling.